### PR TITLE
Release 1.2.1

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,17 +2,19 @@ using Documenter, CausalTables
 
 makedocs(
     sitename="CausalTables.jl",
-    pages = [
+    pages=[
         "Home" => "index.md",
-        "Turning data into a `CausalTable`" =>              "man/formatting.md",
-        "Generating data for statistical experiments" =>    "man/generating-data.md",
-        "Approximating ground truth causal estimands" =>    "man/estimands.md",
-        "Computing ground truth conditional distributions" =>    "man/ground-truth.md",
-        "Network summaries" =>                 "man/network-summaries.md",
-        "Full API" =>                                "man/api.md",
+        "Turning data into a `CausalTable`" => "man/formatting.md",
+        "Generating data for statistical experiments" => "man/generating-data.md",
+        "Approximating ground truth causal estimands" => "man/estimands.md",
+        "Computing ground truth conditional distributions" => "man/ground-truth.md",
+        "Network summaries" => "man/network-summaries.md",
+        "Full API" => "man/api.md",
     ]
 )
 
+
+
 deploydocs(
-    repo = "github.com/salbalkus/CausalTables.jl.git"
+    repo="github.com/salbalkus/CausalTables.jl.git"
 )

--- a/docs/src/man/ground-truth.md
+++ b/docs/src/man/ground-truth.md
@@ -69,7 +69,6 @@ Y_under_treatment = condensity(scm, ct_untreated, :Y)
 One can also compute the ground truth of various functions of these distributions, including the conditional mean (`conmean`), conditional variance (`convar`), or propensity scores (`propensity`; this is the density function evaluated at the observed value of the given variable). To compute other functions of conditional densities not included in CausalTables.jl, please see [Distributions.jl](https://juliastats.org/Distributions.jl/stable/). Below, we show two examples of how one might compute an average treatment effect (ATE) using two different ground-truth functionals of the data.
 
 ```jldoctest truthtest; output = false, filter = r"(?<=.{16}).*"s
-
 ### Plug-in Estimate ###
 μ_treated = conmean(scm, ct_treated, :Y) 
 μ_untreated = conmean(scm, ct_untreated, :Y) 

--- a/src/causal_table.jl
+++ b/src/causal_table.jl
@@ -182,8 +182,7 @@ Replace the fields of a `CausalTable` object with the provided keyword arguments
 A new `CausalTable` object with the specified fields replaced.
 
 """
-replace(o::CausalTable; kwargs...) = CausalTable([field in keys(kwargs) ?  kwargs[field] : getfield(o, field) for field in fieldnames(typeof(o))]...)
-
+Base.replace(o::CausalTable; kwargs...) = CausalTable([field in keys(kwargs) ?  kwargs[field] : getfield(o, field) for field in fieldnames(typeof(o))]...)
 
 """
     getscm(o::CausalTable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ end
 
     # Extra causal-related functions
     more_sums = (S = Sum(:X, :G), T = Sum(:Z, :G), U = Sum(:Y, :G))
-    coltbl2 = CausalTables.replace(coltbl, arrays = (G = [1 0 1; 0 1 1; 0 0 1],), summaries = more_sums)
+    coltbl2 = replace(coltbl, arrays = (G = [1 0 1; 0 1 1; 0 0 1],), summaries = more_sums)
     coltbl2 = summarize(coltbl2) 
     @test coltbl2.treatment == [:X, :S]
     @test coltbl2.causes == (X = [:Z, :T], Y = [:Z, :X, :T, :S], S = [:Z, :T], U = [:Z, :X, :T, :S])
@@ -84,11 +84,11 @@ end
     array = Graphs.adjacency_matrix(Graphs.path_graph(2))
     causalbaz = CausalTables.CausalTable(baz, :X, :Y, (X = [:Z], Y = [:X, :Z]), (A = array,), (B = CausalTables.Sum(:X, :A),))
     @test causalbaz isa CausalTables.CausalTable
-    @test CausalTables.replace(rowtbl; data = baz).data == baz
+    @test replace(rowtbl; data = baz).data == baz
     Tables.subset(coltbl, 1:2)
     @test Tables.subset(coltbl, 1:2).data == (X = X[1:2], Y = Y[1:2], Z = Z[1:2])
     @test Tables.subset(coltbl, 1:2; viewhint = false).data == (X = X[1:2], Y = Y[1:2], Z = Z[1:2])
-    @test CausalTables.replace(rowtbl; treatment = :X).treatment == [:X]
+    @test replace(rowtbl; treatment = :X).treatment == [:X]
     @test vec(CausalTables.treatmentmatrix(coltbl)) == X
     @test vec(CausalTables.responsematrix(coltbl)) == Y
 


### PR DESCRIPTION
Changes `replace` to `Base.replace` to avoid the Base functionality being accidentally overridden.