### PR TITLE
Release 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Given an SCM, it is also possible to approximate the "ground truth" value of a v
 ```
 ate(scm)
 
-(μ = 1.0006736394005957, eff_bound = 2.0019300075151616)
+(μ = 1.0, eff_bound = 6.767108201891064)
 ```
 
 Alternatively, one can compute the ground truth of low-level statistical functionals, such as conditional means or propensity scores, for use in downstream analyses. 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,7 +86,7 @@ For the complete API of available ground truth causal estimands, see [Estimands]
 cfmean(scm, additive_mtp(1))
 
 # output
-(μ = 4.599337273915866, eff_bound = 4.881412474779794)
+(μ = 4.599337273915866,)
 ```
 
 For problems that involving functionals not available through CausalTables.jl or that require more fine-grained knowledge of the true conditional distributions for a given dataset, this package also implements the `condensity` function. This function computes the true conditional distributions of any variable in a CausalTable (given a corresponding DGP). The function returns a vector of Distribution objects from the package [Distributions.jl](https://juliastats.org/Distributions.jl/stable/)

--- a/src/estimands.jl
+++ b/src/estimands.jl
@@ -1,4 +1,4 @@
-# TODO: Currently assumes a single outcome!!
+# TODO: Currently assumes a single outcome
 # TODO: Assumes intervention produces a table
 # TODO: Needs better input processing
 
@@ -317,6 +317,7 @@ function att(scm::StructuralCausalModel; samples = 10^6)
     # Compute the EIF from Theorem 1 of Kennedy, Sjolander, and Small (2015): Semiparametric causal inference in matched cohort studies.
     # Or, check against the code from npcausal: https://rdrr.io/github/ehkennedy/npcausal/src/R/att.R
     μ0 = conmean(scm, ct0, rs)
+
     eif = (@. (A/q) * (Y - μ0) - ((1-A)/(1-q)) * (p / (1-p)) * (Y - μ0))
 
     return((μ = mean(eif), eff_bound = var(eif)))
@@ -372,8 +373,8 @@ function atu(scm::StructuralCausalModel; samples = 10^6)
     q = mean(A)
 
     # Invert the mean from above to estimate E{Y(1)-Y|A=0}
-    μ0 = conmean(scm, ct1, rs)
-    eif = (@. ((1-A) / (1-q)) * (p / (1-p)) * (Y - μ0) - (A / q) * (Y - μ0))
+    μ1 = conmean(scm, ct1, rs)
+    eif = (@. ((1-A) / (1-q)) * (p / (1-p)) * (Y - μ1) - (A / q) * (Y - μ1))
 
     return((μ = mean(eif), eff_bound = var(eif)))
 end

--- a/src/estimands.jl
+++ b/src/estimands.jl
@@ -90,7 +90,6 @@ where ``d(a)`` represents an intervention on the treatment variable(s) ``A``. Th
 # Returns
 A named tuple containing:
 - `μ`: The mean of the counterfactual outcomes.
-- `eff_bound`: The variance of the counterfactual response, which is equal to the efficiency bound for IID data. If observations are correlated, this may not have a meaningful interpretation.
 
 # Example
 ```@example
@@ -133,7 +132,6 @@ where ``d_1`` and ``d_2`` represent `intervention1` and `intervention2` being ap
 # Returns
 A named tuple containing:
 - `μ`: The mean difference in counterfactual outcomes.
-- `eff_bound`: The variance of the difference in counterfactual responses, which is equal to the efficiency bound for IID data. If observations are correlated, this may not have a meaningful interpretation.
 
 # Example
 ```@example
@@ -478,7 +476,6 @@ Convenience functions for generating `intervention` functions include `additive_
 # Returns
 A named tuple containing:
 - `μ`: The ATU approximation.
-- `eff_bound`: The variance of the difference between the natural and counterfactual responses, which is equal to the efficiency bound for IID data. If observations are correlated, this may not have a meaningful interpretation.
 
 # Example
 ```@example

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,13 +323,13 @@ end
     @test all(map(x -> x ∈ [0.0, 1.0], vec(dep)))
 end
 
-@testset "Counterfactual estimand approximation" begin
+#@testset "Counterfactual estimand approximation" begin
     Random.seed!(1234)
 
     # Test binary random variables
     dgp = CausalTables.@dgp(
-        L ~ Beta(2, 4),
-        A ~ @.(Bernoulli(L)),
+        L ~ Beta(1, 1),
+        A ~ @.(Bernoulli(0.6 * L + 0.2)),
         Y ~ @.(Normal(A + 2 * L + 1))
     )
 
@@ -345,20 +345,20 @@ end
     @test all(ctn.data.A .== 0.0)
 
     ε = 0.05
+
     # ATE
     est_ate = ate(scm)
-    @test within(est_ate.μ - 1, ε)
-    @test within(est_ate.eff_bound - 2, ε)
+    @test est_ate.μ == 1.0
+    @test within(est_ate.eff_bound - 4.6, ε)
 
     # ATT
     est_att = att(scm)
-    est_att.μ - 1
     @test within(est_att.μ - 1, ε)
-    @test within(est_att.eff_bound - 2, ε)
+    @test within(est_att.eff_bound - 6.23, ε)
     # ATU
     est_atu = atu(scm)
     @test within(est_atu.μ - 1, ε)
-    @test within(est_atu.eff_bound - 2, ε)
+    @test within(est_atu.eff_bound - 6.23, ε)
 
     # Test continuous random variables
     dgp2 = CausalTables.@dgp(
@@ -379,13 +379,10 @@ end
     # Modified Treatment Policy / Average Policy Effect
     est_ape_a = ape(scm2, additive_mtp(1.0))
     @test within(est_ape_a.μ - 1, ε)
-    @test within(est_ape_a.eff_bound - 2, ε)
     
     est_ape_m = ape(scm2, multiplicative_mtp(1.0))
     @test within(est_ape_m.μ, ε)
-    @test within(est_ape_m.eff_bound - 2, ε)
 
     mean_a = cfmean(scm2, additive_mtp(1.0))
     @test within(mean_a.μ - 3, ε)
-    @test within(mean_a.eff_bound - 2.3, 0.1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,7 +323,7 @@ end
     @test all(map(x -> x ∈ [0.0, 1.0], vec(dep)))
 end
 
-#@testset "Counterfactual estimand approximation" begin
+@testset "Counterfactual estimand approximation" begin
     Random.seed!(1234)
 
     # Test binary random variables


### PR DESCRIPTION
Fix bug with how efficiency bounds were being computed, and remove support for bounds which are not identifiable without additional information (i.e. `cfmean`, `cfdiff`, etc.)